### PR TITLE
bugfix(tools): find protobuf by find_package

### DIFF
--- a/tools/caffe/CMakeLists.txt
+++ b/tools/caffe/CMakeLists.txt
@@ -1,17 +1,9 @@
-
-find_package(Protobuf)
-set(PROTOBUF_INCLUDE_DIR /home/zyhan/anaconda3/include)
-set(PROTOBUF_LIBRARIES /home/zyhan/anaconda3/lib/libprotobuf.so)
-
-if(PROTOBUF_FOUND)
-    protobuf_generate_cpp(CAFFE_PROTO_SRCS CAFFE_PROTO_HDRS caffe.proto)
-    add_executable(caffe2ncnn caffe2ncnn.cpp ${CAFFE_PROTO_SRCS} ${CAFFE_PROTO_HDRS})
-    target_include_directories(caffe2ncnn
-        PRIVATE
-            ${PROTOBUF_INCLUDE_DIR}
-            ${CMAKE_CURRENT_BINARY_DIR})
-    target_compile_features(caffe2ncnn PRIVATE cxx_std_11)
-    target_link_libraries(caffe2ncnn PRIVATE ${PROTOBUF_LIBRARIES})
-else()
-    message(WARNING "Protobuf not found, caffe model convert tool won't be built")
-endif()
+find_package(Protobuf REQUIRED)
+protobuf_generate_cpp(CAFFE_PROTO_SRCS CAFFE_PROTO_HDRS caffe.proto)
+add_executable(caffe2ncnn caffe2ncnn.cpp ${CAFFE_PROTO_SRCS} ${CAFFE_PROTO_HDRS})
+target_include_directories(caffe2ncnn
+    PRIVATE
+        ${Protobuf_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_BINARY_DIR})
+target_compile_features(caffe2ncnn PRIVATE cxx_std_11)
+target_link_libraries(caffe2ncnn PRIVATE ${Protobuf_LIBRARIES})

--- a/tools/onnx/CMakeLists.txt
+++ b/tools/onnx/CMakeLists.txt
@@ -1,17 +1,10 @@
+find_package(Protobuf REQUIRED)
 
-find_package(Protobuf)
-set(PROTOBUF_INCLUDE_DIR /home/zyhan/anaconda3/include)
-set(PROTOBUF_LIBRARIES /home/zyhan/anaconda3/lib/libprotobuf.so)
-
-if(PROTOBUF_FOUND)
-    protobuf_generate_cpp(ONNX_PROTO_SRCS ONNX_PROTO_HDRS onnx.proto)
-    add_executable(onnx2ncnn onnx2ncnn.cpp ${ONNX_PROTO_SRCS} ${ONNX_PROTO_HDRS})
-    target_include_directories(onnx2ncnn
-        PRIVATE
-            ${PROTOBUF_INCLUDE_DIR}
-            ${CMAKE_CURRENT_BINARY_DIR})
-    target_compile_features(onnx2ncnn PRIVATE cxx_std_11)
-    target_link_libraries(onnx2ncnn PRIVATE ${PROTOBUF_LIBRARIES})
-else()
-    message(WARNING "Protobuf not found, onnx model convert tool won't be built")
-endif()
+protobuf_generate_cpp(ONNX_PROTO_SRCS ONNX_PROTO_HDRS onnx.proto)
+add_executable(onnx2ncnn onnx2ncnn.cpp ${ONNX_PROTO_SRCS} ${ONNX_PROTO_HDRS})
+target_include_directories(onnx2ncnn
+    PRIVATE
+        ${Protobuf_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_BINARY_DIR})
+target_compile_features(onnx2ncnn PRIVATE cxx_std_11)
+target_link_libraries(onnx2ncnn PRIVATE ${Protobuf_LIBRARIES})


### PR DESCRIPTION
cmake `find_package`  have supported protobuf since v3.6. We don't need to specify the path of pb manually